### PR TITLE
fix bug read audio array

### DIFF
--- a/glm4_audio_tokenizer/__init__.py
+++ b/glm4_audio_tokenizer/__init__.py
@@ -33,7 +33,7 @@ class Glm4Tokenizer(nn.Module):
                 y, sr = librosa.load(s, sr = sample_rate)
             elif isinstance(s, tuple) or isinstance(s, list):
                 y, sr = s
-                if y > 1:
+                if y.ndim > 1:
                     y = y.mean(0)
                 if sr != sample_rate:
                     y = librosa.resample(y, orig_sr = sr, target_sr = sample_rate)


### PR DESCRIPTION
`if y > 1:`

This incorrectly assumes y is a scalar, but if load from numpy array case, y is a NumPy array. Comparing an array directly like if y > 1 raises:

ValueError: The truth value of an array with more than one element is ambiguous.


fix by:

`y.ndim > 1`